### PR TITLE
Draft VirES record and associated persons

### DIFF
--- a/ESA/PERSON/Ashley.R.A.Smith.xml
+++ b/ESA/PERSON/Ashley.R.A.Smith.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Spase xmlns="http://www.spase-group.org/data/schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.spase-group.org/data/schema  https://www.spase-group.org/data/schema/spase-2.7.1.xsd">
+   <Version>2.7.1</Version>
+   <Person>
+      <ResourceID>spase://ESA/Person/Ashley.R.A.Smith</ResourceID>
+      <NamingAuthority>ESA</NamingAuthority>
+      <PersonName>Ashley R. A. Smith</PersonName>
+      <OrganizationName>mag.earth Ltd, UK</OrganizationName>
+      <Email>ashley@mag.earth</Email>
+      <ORCIdentifier>0000-0001-5198-9574</ORCIdentifier>
+   </Person>
+</Spase>

--- a/ESA/PERSON/EOX.IT.Services.xml
+++ b/ESA/PERSON/EOX.IT.Services.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Spase xmlns="http://www.spase-group.org/data/schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.spase-group.org/data/schema  https://www.spase-group.org/data/schema/spase-2.7.1.xsd">
+   <Version>2.7.1</Version>
+   <Person>
+      <ResourceID>spase://ESA/Person/EOX.IT.Services</ResourceID>
+      <NamingAuthority>ESA</NamingAuthority>
+      <OrganizationName>EOX IT Services GmbH, Austria</OrganizationName>
+      <Email>vires@eox.at</Email>
+      <RORIdentifier>04yk5j107</RORIdentifier>
+   </Person>
+</Spase>

--- a/ESA/PERSON/Martin.Paces.xml
+++ b/ESA/PERSON/Martin.Paces.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Spase xmlns="http://www.spase-group.org/data/schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.spase-group.org/data/schema  https://www.spase-group.org/data/schema/spase-2.7.1.xsd">
+   <Version>2.7.1</Version>
+   <Person>
+      <ResourceID>spase://ESA/Person/Martin.Paces</ResourceID>
+      <NamingAuthority>ESA</NamingAuthority>
+      <PersonName>Martin Pačes</PersonName>
+      <OrganizationName>EOX IT Services GmbH, Austria</OrganizationName>
+      <Email>info@vires.services</Email>
+      <RORIdentifier>04yk5j107</RORIdentifier>
+   </Person>
+</Spase>

--- a/ESA/PERSON/Martin.Paces.xml
+++ b/ESA/PERSON/Martin.Paces.xml
@@ -6,6 +6,7 @@
       <NamingAuthority>ESA</NamingAuthority>
       <PersonName>Martin Pačes</PersonName>
       <OrganizationName>EOX IT Services GmbH, Austria</OrganizationName>
+      <Email>martin.paces@eox.at</Email>
       <Email>info@vires.services</Email>
       <RORIdentifier>04yk5j107</RORIdentifier>
    </Person>

--- a/ESA/Repository/EO/VirES.xml
+++ b/ESA/Repository/EO/VirES.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Spase xmlns="http://www.spase-group.org/data/schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.spase-group.org/data/schema  https://www.spase-group.org/data/schema/spase-2.7.1.xsd">
+   <Version>2.7.1</Version>
+   <Repository>
+      <ResourceID>spase://ESA/Repository/EO/VirES</ResourceID>
+      <NamingAuthority>ESA</NamingAuthority>
+      <ResourceType>Repository</ResourceType>
+      <ResourceHeader>
+         <ResourceName>VirES for Swarm</ResourceName>
+         <ReleaseDate>2026-06-01T00:00:00</ReleaseDate>
+         <Description>VirES provides access to ESA Swarm mission products and related datasets and models</Description>
+         <Contact>
+            <PersonID>spase://ESA/Person/Ashley.R.A.Smith</PersonID>
+            <Role>MetadataContact</Role>
+            <Role>TechnicalContact</Role>
+            <Role>Scientist</Role>
+         </Contact>
+         <Contact>
+            <PersonID>spase://ESA/Person/Martin.Paces</PersonID>
+            <Role>TechnicalContact</Role>
+         </Contact>
+         <Contact>
+            <PersonID>spase://ESA/Person/EOX.IT.Services</PersonID>
+            <Role>TechnicalContact</Role>
+         </Contact>
+         <InformationURL>
+            <Name>Swarm Handbook</Name>
+            <URL>https://swarmhandbook.earth.esa.int/catalogue/index</URL>
+            <Description>Upstream catalogue describing Swarm products</Description>
+         </InformationURL>
+         <InformationURL>
+            <Name>Description of VirES for Swarm</Name>
+            <URL>https://earth.esa.int/eogateway/tools/vires-for-swarm</URL>
+         </InformationURL>
+      </ResourceHeader>
+      <AccessURL>
+         <URL>https://vires.services</URL>
+      </AccessURL>
+   </Repository>
+</Spase>


### PR DESCRIPTION
This adds a record with resource ID `spase://ESA/Repository/EO/VirES`

Still to check - should we go ahead with including `EO` in the path? (or perhaps `EarthObservation`)